### PR TITLE
Support for PHP 8.4

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -13,4 +13,18 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+
+    <issueHandlers>
+        <!-- Don't warn about methods only available in later PHP versions -->
+        <UndefinedMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="Random\Randomizer::getFloat" />
+            </errorLevel>
+        </UndefinedMethod>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Random\Randomizer" />
+            </errorLevel>
+        </UndefinedClass>
+    </issueHandlers>
 </psalm>

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1072,7 +1072,13 @@ class Builder extends BuilderAbstract
      */
     private function random_float(float|int $min, float|int $max): float
     {
-        # See https://www.php.net/manual/en/function.mt-rand.php#75793
-        return ($min + lcg_value() * (abs($max - $min)));
+        if (class_exists(\Random\Randomizer::class) && method_exists(\Random\Randomizer::class, "getFloat")) {
+            # getFloat() was introduced in PHP 8.3
+            $randomizer = new \Random\Randomizer();
+            return $randomizer->getFloat($min, $max);
+        } else {
+            # See https://www.php.net/manual/en/function.mt-rand.php#75793
+            return ($min + lcg_value() * (abs($max - $min)));
+        }
     }
 }

--- a/src/Helpers/Dir.php
+++ b/src/Helpers/Dir.php
@@ -49,11 +49,11 @@ class Dir
      * Get all files
      *
      * @param string $dir
-     * @param array $ignore
+     * @param array|null $ignore
      * @param bool $absolute
      * @return array
      */
-    public static function files(string $dir, array $ignore = null, bool $absolute = false): array
+    public static function files(string $dir, ?array $ignore = null, bool $absolute = false): array
     {
         $result = array_values(array_filter(static::read($dir, $ignore, true), 'is_file'));
 
@@ -108,11 +108,11 @@ class Dir
      * It skips unwanted invisible stuff.
      *
      * @param string $dir The path of directory
-     * @param array $ignore Optional array with filenames, which should be ignored
+     * @param array|null $ignore Optional array with filenames, which should be ignored
      * @param bool $absolute If true, the full path for each item will be returned
      * @return array An array of filenames
      */
-    public static function read(string $dir, array $ignore = null, bool $absolute = false): array
+    public static function read(string $dir, ?array $ignore = null, bool $absolute = false): array
     {
         if (is_dir($dir) === false) {
             return [];

--- a/src/Helpers/F.php
+++ b/src/Helpers/F.php
@@ -45,10 +45,10 @@ class F
      * Checks if the file exists on disk
      *
      * @param string $file
-     * @param string $in
+     * @param string|null $in
      * @return bool
      */
-    public static function exists(string $file, string $in = null): bool
+    public static function exists(string $file, ?string $in = null): bool
     {
         try {
             static::realpath($file, $in);
@@ -62,11 +62,11 @@ class F
     /**
      * Gets the extension of a file
      *
-     * @param string $file The filename or path
-     * @param string $extension Set an optional extension to overwrite the current one
+     * @param string|null $file The filename or path
+     * @param string|null $extension Set an optional extension to overwrite the current one
      * @return string
      */
-    public static function extension(string $file = null, string $extension = null): string
+    public static function extension(?string $file = null, ?string $extension = null): string
     {
         // overwrite the current extension
         if ($extension !== null) {
@@ -130,10 +130,10 @@ class F
      * Returns the absolute path to the file if the file can be found.
      *
      * @param string $file
-     * @param string $in
+     * @param string|null $in
      * @return string|null
      */
-    public static function realpath(string $file, string $in = null)
+    public static function realpath(string $file, ?string $in = null)
     {
         $realpath = realpath($file);
 

--- a/src/Helpers/Mime.php
+++ b/src/Helpers/Mime.php
@@ -2,9 +2,6 @@
 
 namespace SimpleCaptcha\Helpers;
 
-use SimpleCaptcha\Helpers\F;
-
-
 /**
  * The `Mime` class provides method
  * for MIME type detection or guessing
@@ -168,10 +165,10 @@ class Mime
      * Returns the MIME type of a file
      *
      * @param string $file
-     * @param string $extension
+     * @param string|null $extension
      * @return string|false
      */
-    public static function type(string $file, string $extension = null)
+    public static function type(string $file, ?string $extension = null)
     {
         // use the standard finfo extension
         $mime = static::fromFileInfo($file);

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -24,7 +24,7 @@ class Str
      * @param bool $caseInsensitive
      * @return bool
      */
-    public static function contains(string $string = null, string $needle, bool $caseInsensitive = false): bool
+    public static function contains(string $string, string $needle, bool $caseInsensitive = false): bool
     {
         if ($needle === '') {
             return true;
@@ -38,10 +38,10 @@ class Str
     /**
      * A UTF-8 safe version of strlen()
      *
-     * @param string $string
+     * @param string|null $string
      * @return int
      */
-    public static function length(string $string = null): int
+    public static function length(?string $string = null): int
     {
         return mb_strlen($string ?? '', 'UTF-8');
     }
@@ -50,10 +50,10 @@ class Str
     /**
      * A UTF-8 safe version of strtolower()
      *
-     * @param string $string
+     * @param string|null $string
      * @return string
      */
-    public static function lower(string $string = null): string
+    public static function lower(?string $string = null): string
     {
         return mb_strtolower($string ?? '', 'UTF-8');
     }
@@ -81,7 +81,7 @@ class Str
      * @param bool $caseInsensitive
      * @return int|bool
      */
-    public static function position(string $string = null, string $needle, bool $caseInsensitive = false)
+    public static function position(string $string, string $needle, bool $caseInsensitive = false)
     {
         if ($caseInsensitive === true) {
             $string = static::lower($string);
@@ -113,7 +113,7 @@ class Str
      * @param bool $caseInsensitive
      * @return bool
      */
-    public static function startsWith(string $string = null, string $needle, bool $caseInsensitive = false): bool
+    public static function startsWith(string $string, string $needle, bool $caseInsensitive = false): bool
     {
         if ($needle === '') {
             return true;
@@ -131,9 +131,9 @@ class Str
      * @param int $length
      * @return string
      */
-    public static function substr(string $string = null, int $start = 0, int $length = null): string
+    public static function substr(string $string, int $start, int $length): string
     {
-        return mb_substr($string ?? '', $start, $length, 'UTF-8');
+        return mb_substr($string, $start, $length, 'UTF-8');
     }
 
 


### PR DESCRIPTION
Hi!
It would be great if your library would support PHP 8.4 (without deprecations). Here would be my suggestion:
- Use `\Random\Randomizer::getRandom()` instead of `lcg_value` (if available)
- Added nullability to parameters when appropriate 
- Removed some `null` values if I couldn't find a nullable use (expect for from within test cases)
- Removed default parameters before mandatory parameters
- One unused import (unreleated)